### PR TITLE
With project image field

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -30,6 +30,7 @@ class Project_add(models.Model):
     link = models.CharField(max_length=200)
     stack = models.CharField(max_length=300)
     date = models.CharField(max_length=100)
+    proj_image= models.ImageField(upload_to='media/proj_image/')
 
     def save(self, *args, **kwargs):
         self.pid = str(str(self.name[0:3])+'_'+str(self.date).split(' ')[0].split('-')[2])

--- a/home/views.py
+++ b/home/views.py
@@ -226,8 +226,9 @@ def project_add(request):
         desc = request.POST.get('desc')
         link = request.POST.get('link')
         stack = request.POST.getlist('stack')
+	proj_image = request.POST.get('proj_image')
         project_add = Project_add(
-            name=name, desc=desc, link=link, stack=stack, date=datetime.today())
+            name=name, desc=desc, link=link, stack=stack, proj_image=proj_image, date=datetime.today())
         project_add.save()
         messages.success(request, 'Your Project has been added')
 

--- a/templates/project_add.html
+++ b/templates/project_add.html
@@ -21,14 +21,19 @@
     <label for="link">Link(Site link or github link if any)</label>
     <input type="text" class="form-control" id="link" name="link" placeholder="https://...">
   </div>
-
+ 
+      
   <div class="form-group">
     <label for="stack">Technical Stack</label> <br>
     <!----- add tech stack choices ------->
     <div class="dropdown" style="">
       <button class="btn bg-dark text-white dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Choose tech stack
-      </button>
+      </button><br><br>
+      <div class="form-group">
+        <label for="proj_image">Project Image</label> <br>
+        <input type="file">
+      </div>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
         {% for key,value in tags.items %}
         <input type="checkbox" value={{key}} name="stack" id="{{value}}"> <label for="{{value}}"> {{key}}</label> <br />


### PR DESCRIPTION
# Description:

While entering details of project there must be an option to upload image related to the project . 
`python manage.py makemigrations`
`python manage.py migrate`
Kindly make migrations for this code to work. Unless migrations have been done you cannot see the desired output.
As the footer overlaps, change the page size to make all divisions visible.

Fixes #6 

## Type of change:

1. Models.py --> Added a field for image upload
2. Views.py --> Added view for image field
3. project_add.html --> added division for image upload option
 
# Checklist:
- [x] Made migrations
- [x] Upload option visibility
- [x] Attach a picture

# Screenshots / Video:

![Screenshot (973)](https://user-images.githubusercontent.com/64252906/114006061-bfbb7700-987d-11eb-934f-3e855f98fd3d.png)
![Screenshot (974)](https://user-images.githubusercontent.com/64252906/114006071-c1853a80-987d-11eb-9421-653a99e04bea.png)
![Screenshot (975)](https://user-images.githubusercontent.com/64252906/114006077-c21dd100-987d-11eb-990b-57b4834dae12.png)

